### PR TITLE
Add unknown type to MTGSet.Type, unknown check in new cards unit test

### DIFF
--- a/Sources/ScryfallKit/Models/Card/Card+enums.swift
+++ b/Sources/ScryfallKit/Models/Card/Card+enums.swift
@@ -132,7 +132,7 @@ extension Card {
         case reversibleCard = "reversible_card"
 
         public init(from decoder: Decoder) throws {
-            self = try Layout(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+            self = try Self(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
             if self == .unknown, let rawValue = try? String(from: decoder) {
                 print("Decoded unknown FrameEffect: \(rawValue)")
             }

--- a/Sources/ScryfallKit/Models/Card/Card.swift
+++ b/Sources/ScryfallKit/Models/Card/Card.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 
-// swiftlint:disable type_body_length
 /// A Magic: the Gathering card
 ///
 /// Full reference: https://scryfall.com/docs/api/cards
@@ -253,4 +252,5 @@ public struct Card: Codable, Identifiable, Hashable {
         self.watermark = watermark
         self.preview = preview
     }
+    // swiftlint:enable function_body_length
 }

--- a/Sources/ScryfallKit/Models/MTGSet.swift
+++ b/Sources/ScryfallKit/Models/MTGSet.swift
@@ -28,12 +28,19 @@ public struct MTGSet: Codable, Identifiable, Hashable {
     public enum `Type`: String, Codable {
         // While "masters" is in fact not inclusive, it's also a name that we can't control
         // swiftlint:disable:next inclusive_language
-        case core, expansion, masters, masterpiece, spellbook, commander, planechase, archenemy, vanguard, funny, starter, box, promo, token, memorabilia, arsenal, alchemy, minigame
+        case core, expansion, masters, masterpiece, spellbook, commander, planechase, archenemy, vanguard, funny, starter, box, promo, token, memorabilia, arsenal, alchemy, minigame, unknown
         case fromTheVault = "from_the_vault"
         case premiumDeck = "premium_deck"
         case duelDeck = "duel_deck"
         case draftInnovation = "draft_innovation"
         case treasureChest = "treasure_chest"
+
+        public init(from decoder: Decoder) throws {
+            self = try Self(rawValue: decoder.singleValueContainer().decode(RawValue.self)) ?? .unknown
+            if self == .unknown, let rawValue = try? String(from: decoder) {
+                print("Decoded unknown MTGSet Type: \(rawValue)")
+            }
+        }
     }
 
     public var id: UUID

--- a/Tests/ScryfallKitTests/SmokeTests.swift
+++ b/Tests/ScryfallKitTests/SmokeTests.swift
@@ -160,6 +160,8 @@ final class SmokeTests: XCTestCase {
 
         // Search
         var results = try await client.searchCards(filters: [filter])
+        XCTAssert(results.data.allSatisfy { $0.setType != .unknown })
+        XCTAssert(results.data.allSatisfy { $0.layout != .unknown })
         var page = 1
 
         // Go through every page


### PR DESCRIPTION
As MTG evolves, it can be expected that WOTC will add new types that will have to be accounted for by the enums in ScryfallKit. In an effort to eliminate the need for panic patches when Scryfall updates their API, I've added the `unknown` type to the `MTGSet.Type` enum. This means that when an unknown enum type is added, ScryfallKit won't throw a decoding error but will instead return a type of `unknown`.

To ensure that ScryfallKit continues to be updated instead of becoming reliant on the `unknown` types, I've also added assertions in the new cards test function that will fail if they detect any card with an `unknown` property.