### PR TITLE
Update Card+ImageUris.swift

### DIFF
--- a/Sources/ScryfallKit/Models/Card/Card+ImageUris.swift
+++ b/Sources/ScryfallKit/Models/Card/Card+ImageUris.swift
@@ -7,15 +7,6 @@ import Foundation
 extension Card {
     /// Image URIs for each ``Card/ImageType``
     public struct ImageUris: Codable, Hashable, Sendable {
-        private enum CodingKeys: String, CodingKey {
-            case small
-            case normal
-            case large
-            case png
-            case artCrop = "art_crop"
-            case borderCrop = "border_crop"
-        }
-
         /// A link to a small full card image.
         /// - Note: Designed for use as thumbnail or list icon.
         public let small: String?


### PR DESCRIPTION
closes #21 

Fixed artCrop and borderCrop not decoding properly by removing custom CodingKeys. The JSON decoder used in the networking client already converts from snakeCase when decoding the API response; these coding keys were inadvertently causing a coding key mis-match.

JSON decoder as set up in `NetworkService.swift`, lines 75 & 76:

```swift
let decoder = JSONDecoder()
decoder.keyDecodingStrategy = .convertFromSnakeCase
```

A quick test with the local changes (removing the custom coding keys) has solved the issue in my test app.