### PR TITLE
Make ScryfallClient Sendable

### DIFF
--- a/Sources/ScryfallKit/Networking/NetworkService.swift
+++ b/Sources/ScryfallKit/Networking/NetworkService.swift
@@ -13,7 +13,7 @@ public enum NetworkLogLevel: Sendable {
     case verbose
 }
 
-protocol NetworkServiceProtocol {
+protocol NetworkServiceProtocol: Sendable {
     func request<T: Decodable>(_ request: EndpointRequest, as type: T.Type, completion: @Sendable @escaping (Result<T, Error>) -> Void)
     @available(macOS 10.15.0, *, iOS 13.0.0, *)
     func request<T: Decodable>(_ request: EndpointRequest, as type: T.Type) async throws -> T

--- a/Sources/ScryfallKit/ScryfallClient.swift
+++ b/Sources/ScryfallKit/ScryfallClient.swift
@@ -5,9 +5,9 @@
 import Foundation
 
 /// A client for interacting with the Scryfall API
-public final class ScryfallClient {
-    private var networkLogLevel: NetworkLogLevel
-    var networkService: NetworkServiceProtocol
+public final class ScryfallClient: Sendable {
+    private let networkLogLevel: NetworkLogLevel
+    let networkService: NetworkServiceProtocol
 
     /// Initialize an instance of the ScryfallClient
     /// - Parameter networkLogLevel: The desired logging level. See ``NetworkLogLevel``


### PR DESCRIPTION
ScryfallClient is currently thread-safe, but we still need to ensure it is marked as Sendable for Swift 6 strict concurrency mode.