### PR TITLE
Adding etched price to prices

### DIFF
--- a/Sources/ScryfallKit/Extensions/Card+helpers.swift
+++ b/Sources/ScryfallKit/Extensions/Card+helpers.swift
@@ -46,6 +46,7 @@ extension Card {
     case .eur: return prices.eur
     case .tix: return prices.tix
     case .usdFoil: return prices.usdFoil
+    case .usdEtched: return prices.usdEtched
     }
   }
 }

--- a/Sources/ScryfallKit/Models/Card/Card+Prices.swift
+++ b/Sources/ScryfallKit/Models/Card/Card+Prices.swift
@@ -11,14 +11,18 @@ extension Card {
     public var usd: String?
     /// The price of this card's foil printing in usd
     public var usdFoil: String?
+    /// The price of this card's etched printing in usd
+    public var usdEtched: String?
     /// The price of this card in eur.
     public var eur: String?
+//    "usd_etched": "40.45"
 
-    public init(tix: String? = nil, usd: String? = nil, usdFoil: String? = nil, eur: String? = nil)
+    public init(tix: String? = nil, usd: String? = nil, usdFoil: String? = nil, usdEtched: String? = nil, eur: String? = nil)
     {
       self.tix = tix
       self.usd = usd
       self.usdFoil = usdFoil
+      self.usdEtched = usdEtched
       self.eur = eur
     }
   }

--- a/Sources/ScryfallKit/Models/Card/Card+Prices.swift
+++ b/Sources/ScryfallKit/Models/Card/Card+Prices.swift
@@ -15,7 +15,6 @@ extension Card {
     public var usdEtched: String?
     /// The price of this card in eur.
     public var eur: String?
-//    "usd_etched": "40.45"
 
     public init(tix: String? = nil, usd: String? = nil, usdFoil: String? = nil, usdEtched: String? = nil, eur: String? = nil)
     {

--- a/Sources/ScryfallKit/Models/Enums.swift
+++ b/Sources/ScryfallKit/Models/Enums.swift
@@ -37,5 +37,5 @@ public enum Format: String, CaseIterable, Sendable {
 
 /// Currency types that Scryfall provides prices for
 public enum Currency: String, CaseIterable, Sendable {
-  case usd, eur, tix, usdFoil
+  case usd, eur, tix, usdFoil, usdEtched
 }


### PR DESCRIPTION
### This PR adds the usdEtched price field to the Prices struct.



For Etched foil cards, prices are listed in their own field in the prices response. 

[This card](https://scryfall.com/card/cmr/539/tymna-the-weaver), for example, does not list a price under the 'usd' field or the 'usd_foil' field, but instead under a new field, 'usd_etched'.

![Screenshot 2025-02-06 at 9 04 04 PM](https://github.com/user-attachments/assets/54d95c59-9f75-4ad1-bf75-de65ab847e62)

![Screenshot 2025-02-06 at 9 03 53 PM](https://github.com/user-attachments/assets/35e2a87b-a9c3-45ac-a62a-b4ce2ace552b)

