### PR TITLE
Adding WatchOS availability & decoding conformance to Card

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
   name: "ScryfallKit",
-  platforms: [.macOS(.v10_13), .iOS(.v12)],
+  platforms: [.macOS(.v10_13), .iOS(.v12), .watchOS(.v11)],
   products: [
     .library(
       name: "ScryfallKit",

--- a/Sources/ScryfallKit/Logger.swift
+++ b/Sources/ScryfallKit/Logger.swift
@@ -7,6 +7,8 @@ import OSLog
 
 @available(macOS 11.0, *)
 @available(iOS 14.0, *)
+@available(watchOS 11.0, *)
+
 extension Logger {
   static let subsystem = "dev.hearst.scryfallkit"
   static let main = Logger(subsystem: subsystem, category: "ScryfallKit")

--- a/Sources/ScryfallKit/Models/Card/Card+Face.swift
+++ b/Sources/ScryfallKit/Models/Card/Card+Face.swift
@@ -59,21 +59,21 @@ extension Card {
 
     enum CodingKeys: String, CodingKey {
       case artist
-      case colorIndicator = "color_indicator"
+      case colorIndicator //= "color_indicator"
       case colors
-      case flavorText = "flavor_text"
-      case illustrationId = "illustration_id"
-      case imageUris = "image_uris"
+      case flavorText //= "flavor_text"
+      case illustrationId// = "illustration_id"
+      case imageUris //= "image_uris"
       case loyalty
-      case manaCost = "mana_cost"
+      case manaCost //= "mana_cost"
       case name
-      case oracleText = "oracle_text"
+      case oracleText// = "oracle_text"
       case power
       case printedName = "printed_name"
-      case printedText = "printed_text"
-      case printedTypeLine = "printed_type_line"
+      case printedText// = "printed_text"
+      case printedTypeLine //= "printed_type_line"
       case toughness
-      case typeLine = "type_line"
+      case typeLine //= "type_line"
       case watermark
     }
 

--- a/Sources/ScryfallKit/Models/Card/Card+Face.swift
+++ b/Sources/ScryfallKit/Models/Card/Card+Face.swift
@@ -57,26 +57,6 @@ extension Card {
     /// This card's watermark, if any
     public var watermark: String?
 
-    enum CodingKeys: String, CodingKey {
-      case artist
-      case colorIndicator //= "color_indicator"
-      case colors
-      case flavorText //= "flavor_text"
-      case illustrationId// = "illustration_id"
-      case imageUris //= "image_uris"
-      case loyalty
-      case manaCost //= "mana_cost"
-      case name
-      case oracleText// = "oracle_text"
-      case power
-      case printedName = "printed_name"
-      case printedText// = "printed_text"
-      case printedTypeLine //= "printed_type_line"
-      case toughness
-      case typeLine //= "type_line"
-      case watermark
-    }
-
     public init(
       artist: String? = nil,
       colorIndicator: [Card.Color]? = nil,

--- a/Sources/ScryfallKit/Models/Card/Card+Face.swift
+++ b/Sources/ScryfallKit/Models/Card/Card+Face.swift
@@ -57,6 +57,26 @@ extension Card {
     /// This card's watermark, if any
     public var watermark: String?
 
+    enum CodingKeys: String, CodingKey {
+      case artist
+      case colorIndicator = "color_indicator"
+      case colors
+      case flavorText = "flavor_text"
+      case illustrationId = "illustration_id"
+      case imageUris = "image_uris"
+      case loyalty
+      case manaCost = "mana_cost"
+      case name
+      case oracleText = "oracle_text"
+      case power
+      case printedName = "printed_name"
+      case printedText = "printed_text"
+      case printedTypeLine = "printed_type_line"
+      case toughness
+      case typeLine = "type_line"
+      case watermark
+    }
+
     public init(
       artist: String? = nil,
       colorIndicator: [Card.Color]? = nil,

--- a/Sources/ScryfallKit/Models/Card/Card.swift
+++ b/Sources/ScryfallKit/Models/Card/Card.swift
@@ -100,6 +100,8 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
   // MARK: Print fields
   /// The name of the artist who illustrated this card
   public var artist: String?
+  /// An array of IDs that map to the artists who illustrated the card
+  public var artistIds: [String]?
   /// True if this card was printed in booster packs
   public var booster: Bool
   /// The color of this card's border
@@ -127,6 +129,8 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
   public var frame: Frame
   /// True if this card's art is larger than normal
   public var fullArt: Bool
+  /// A description of what security stamp the card has - for Unfinity cards, will be "acorn", for normal rares, "oval"
+  public var securityStamp: String?
   /// An array of the games this card has been released in
   public var games: [Game]
   /// True if Scryfall has a high-res image of this card
@@ -169,6 +173,8 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
   public var setType: MTGSet.`Type`
   /// A link to this card's set object on the Scryfall API
   public var setUri: String
+  /// A unique ID that identifies what set the card came from.
+  public var setId: String?
   /// This card's set code
   public var set: String
   /// True if this was a story spotlight card
@@ -184,6 +190,71 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
   /// An object with information on when this card was previewed and by whom
   public var preview: Preview?
 
+  enum CodingKeys: String, CodingKey {
+    case id
+    case oracleId = "oracle_id"
+    case multiverseIds = "multiverse_ids"
+    case mtgoId = "mtgo_id"
+    case arenaId = "arena_id"
+    case tcgplayerId = "tcgplayer_id"
+    case cardMarketId = "cardmarket_id"
+    case name
+    case lang
+    case releasedAt = "released_at"
+    case uri
+    case scryfallUri = "scryfall_uri"
+    case layout
+    case highresImage = "highres_image"
+    case imageStatus = "image_status"
+    case imageUris = "image_uris"
+    case manaCost = "mana_cost"
+    case cmc
+    case typeLine = "type_line"
+    case oracleText = "oracle_text"
+    case power
+    case toughness
+    case colors
+    case colorIdentity = "color_identity"
+    case keywords
+    case legalities
+    case games
+    case reserved
+    case finishes
+    case oversized
+    case promo
+    case promoTypes = "promo_types"
+    case reprint
+    case variation
+    case setId = "set_id"
+    case set
+    case setName = "set_name"
+    case setType = "set_type"
+    case setUri = "set_uri"
+    case setSearchUri = "set_search_uri"
+    case scryfallSetUri = "scryfall_set_uri"
+    case rulingsUri = "rulings_uri"
+    case printsSearchUri = "prints_search_uri"
+    case collectorNumber = "collector_number"
+    case digital
+    case rarity
+    case cardBackId = "card_back_id"
+    case artist
+    case artistIds = "artist_ids"
+    case illustrationId = "illustration_id"
+    case borderColor = "border_color"
+    case frame
+    case frameEffects = "frame_effects"
+    case securityStamp = "security_stamp"
+    case fullArt = "full_art"
+    case textless
+    case booster
+    case storySpotlight = "story_spotlight"
+    case edhrecRank = "edhrec_rank"
+    case prices
+    case relatedUris = "related_uris"
+    case purchaseUris = "purchase_uris"
+  }
+
   // swiftlint:disable function_body_length
   public init(
     arenaId: Int? = nil,
@@ -196,7 +267,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     id: UUID,
     oracleId: String,
     lang: String,
-  printsSearchUri: String? = nil,
+    printsSearchUri: String? = nil,
     rulingsUri: String? = nil,
     scryfallUri: String? = nil,
     uri: String,
@@ -223,6 +294,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     toughness: String? = nil,
     typeLine: String? = nil,
     artist: String? = nil,
+    artistIds: [String]? = nil,
     booster: Bool,
     borderColor: BorderColor,
     cardBackId: UUID? = nil,
@@ -235,6 +307,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     frameEffects: [FrameEffect]? = nil,
     frame: Frame,
     fullArt: Bool,
+    securityStamp: String? = nil,
     games: [Game],
     highresImage: Bool,
     illustrationId: UUID? = nil,
@@ -301,6 +374,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     self.toughness = toughness
     self.typeLine = typeLine
     self.artist = artist
+    self.artistIds = artistIds
     self.booster = booster
     self.borderColor = borderColor
     self.cardBackId = cardBackId
@@ -313,6 +387,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     self.frameEffects = frameEffects
     self.frame = frame
     self.fullArt = fullArt
+    self.securityStamp = securityStamp
     self.games = games
     self.highresImage = highresImage
     self.illustrationId = illustrationId

--- a/Sources/ScryfallKit/Models/Card/Card.swift
+++ b/Sources/ScryfallKit/Models/Card/Card.swift
@@ -52,7 +52,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
   /// An array of colors representing this card's color identity.
   ///
   /// Color identity is used to determine what cards are legal in a Commander deck. See the [comprehensive rules](https://magic.wizards.com/en/rules) for more information
-  public var colorIdentity: [Color]
+  public var colorIdentity: [Color]?
   /// An array of the colors in this card’s color indicator or nil if it doesn't have one
   ///
   /// Color indicators are used to specify the color of a card that has no mana symbols
@@ -196,14 +196,14 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     id: UUID,
     oracleId: String,
     lang: String,
-    printsSearchUri: String?,
-    rulingsUri: String?,
-    scryfallUri: String?,
+  printsSearchUri: String? = nil,
+    rulingsUri: String? = nil,
+    scryfallUri: String? = nil,
     uri: String,
     allParts: [RelatedCard]? = nil,
     cardFaces: [Face]? = nil,
     cmc: Double,
-    colorIdentity: [Color],
+    colorIdentity: [Color]? = nil,
     colorIndicator: [Color]? = nil,
     colors: [Color]? = nil,
     edhrecRank: Int? = nil,

--- a/Sources/ScryfallKit/Models/Card/Card.swift
+++ b/Sources/ScryfallKit/Models/Card/Card.swift
@@ -35,7 +35,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
   /// A link to where you can begin paginating all re/prints for this card on Scryfall’s API.
   public var printsSearchUri: String?
   /// A link to this card’s rulings list on Scryfall’s API.
-  public var rulingsUri: String
+  public var rulingsUri: String?
   /// A link to this card’s permapage on Scryfall’s website.
   public var scryfallUri: String
   /// A link to this card object on Scryfall’s API.
@@ -197,7 +197,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     oracleId: String,
     lang: String,
     printsSearchUri: String?,
-    rulingsUri: String,
+    rulingsUri: String?,
     scryfallUri: String,
     uri: String,
     allParts: [RelatedCard]? = nil,

--- a/Sources/ScryfallKit/Models/Card/Card.swift
+++ b/Sources/ScryfallKit/Models/Card/Card.swift
@@ -37,7 +37,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
   /// A link to this card’s rulings list on Scryfall’s API.
   public var rulingsUri: String?
   /// A link to this card’s permapage on Scryfall’s website.
-  public var scryfallUri: String
+  public var scryfallUri: String?
   /// A link to this card object on Scryfall’s API.
   public var uri: String
 
@@ -198,7 +198,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     lang: String,
     printsSearchUri: String?,
     rulingsUri: String?,
-    scryfallUri: String,
+    scryfallUri: String?,
     uri: String,
     allParts: [RelatedCard]? = nil,
     cardFaces: [Face]? = nil,

--- a/Sources/ScryfallKit/Models/Card/Card.swift
+++ b/Sources/ScryfallKit/Models/Card/Card.swift
@@ -33,7 +33,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
   /// The language that this specific printing was printed in
   public var lang: String
   /// A link to where you can begin paginating all re/prints for this card on Scryfall’s API.
-  public var printsSearchUri: String
+  public var printsSearchUri: String?
   /// A link to this card’s rulings list on Scryfall’s API.
   public var rulingsUri: String
   /// A link to this card’s permapage on Scryfall’s website.
@@ -196,7 +196,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     id: UUID,
     oracleId: String,
     lang: String,
-    printsSearchUri: String,
+    printsSearchUri: String?,
     rulingsUri: String,
     scryfallUri: String,
     uri: String,

--- a/Sources/ScryfallKit/Models/Card/Card.swift
+++ b/Sources/ScryfallKit/Models/Card/Card.swift
@@ -37,7 +37,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
   /// A link to this card’s rulings list on Scryfall’s API.
   public var rulingsUri: String
   /// A link to this card’s permapage on Scryfall’s website.
-  public var scryfallUri: String?
+  public var scryfallUri: String
   /// A link to this card object on Scryfall’s API.
   public var uri: String
 
@@ -174,7 +174,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
   /// A link to this card's set object on the Scryfall API
   public var setUri: String
   /// A unique ID that identifies what set the card came from.
-  public var setId: String?
+  public var setId: String
   /// This card's set code
   public var set: String
   /// True if this was a story spotlight card
@@ -270,7 +270,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     lang: String,
     printsSearchUri: String? = nil,
     rulingsUri: String,
-    scryfallUri: String? = nil,
+    scryfallUri: String,
     uri: String,
     allParts: [RelatedCard]? = nil,
     cardFaces: [Face]? = nil,
@@ -330,6 +330,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     setSearchUri: URL,
     setType: MTGSet.`Type`,
     setUri: String,
+    setId: String,
     set: String,
     storySpotlight: Bool,
     textless: Bool,
@@ -410,6 +411,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     self.setSearchUri = setSearchUri
     self.setType = setType
     self.setUri = setUri
+    self.setId = setId
     self.set = set
     self.storySpotlight = storySpotlight
     self.textless = textless

--- a/Sources/ScryfallKit/Models/Card/Card.swift
+++ b/Sources/ScryfallKit/Models/Card/Card.swift
@@ -35,7 +35,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
   /// A link to where you can begin paginating all re/prints for this card on Scryfall’s API.
   public var printsSearchUri: String?
   /// A link to this card’s rulings list on Scryfall’s API.
-  public var rulingsUri: String?
+  public var rulingsUri: String
   /// A link to this card’s permapage on Scryfall’s website.
   public var scryfallUri: String?
   /// A link to this card object on Scryfall’s API.
@@ -52,7 +52,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
   /// An array of colors representing this card's color identity.
   ///
   /// Color identity is used to determine what cards are legal in a Commander deck. See the [comprehensive rules](https://magic.wizards.com/en/rules) for more information
-  public var colorIdentity: [Color]?
+  public var colorIdentity: [Color]
   /// An array of the colors in this card’s color indicator or nil if it doesn't have one
   ///
   /// Color indicators are used to specify the color of a card that has no mana symbols
@@ -269,13 +269,13 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     oracleId: String,
     lang: String,
     printsSearchUri: String? = nil,
-    rulingsUri: String? = nil,
+    rulingsUri: String,
     scryfallUri: String? = nil,
     uri: String,
     allParts: [RelatedCard]? = nil,
     cardFaces: [Face]? = nil,
     cmc: Double,
-    colorIdentity: [Color]? = nil,
+    colorIdentity: [Color],
     colorIndicator: [Color]? = nil,
     colors: [Color]? = nil,
     edhrecRank: Int? = nil,

--- a/Sources/ScryfallKit/Models/Card/Card.swift
+++ b/Sources/ScryfallKit/Models/Card/Card.swift
@@ -130,7 +130,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
   /// True if this card's art is larger than normal
   public var fullArt: Bool
   /// A description of what security stamp the card has - for Unfinity cards, will be "acorn", for normal rares, "oval"
-  public var securityStamp: String?
+  public var securityStamp: SecurityStamp?
   /// An array of the games this card has been released in
   public var games: [Game]
   /// True if Scryfall has a high-res image of this card
@@ -160,7 +160,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
   /// A dictionary of links to other MTG resources
   public var relatedUris: [String: String]
   /// This card's release date
-  public var releasedAt: String
+  public var releasedAt: String?
   /// True if this card has been printed before
   public var reprint: Bool
   /// Link to this card's set on Scryfall
@@ -189,72 +189,6 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
   public var watermark: String?
   /// An object with information on when this card was previewed and by whom
   public var preview: Preview?
-
-  enum CodingKeys: String, CodingKey {
-    case id
-    case oracleId = "oracle_id"
-    case multiverseIds = "multiverse_ids"
-    case mtgoId = "mtgo_id"
-    case arenaId = "arena_id"
-    case tcgplayerId = "tcgplayer_id"
-    case cardMarketId = "cardmarket_id"
-    case name
-    case lang
-    case releasedAt = "released_at"
-    case uri
-    case scryfallUri = "scryfall_uri"
-    case layout
-    case highresImage = "highres_image"
-    case imageStatus = "image_status"
-    case imageUris = "image_uris"
-    case manaCost = "mana_cost"
-    case cardFaces = "card_faces"
-    case cmc
-    case typeLine = "type_line"
-    case oracleText = "oracle_text"
-    case power
-    case toughness
-    case colors
-    case colorIdentity = "color_identity"
-    case keywords
-    case legalities
-    case games
-    case reserved
-    case finishes
-    case oversized
-    case promo
-    case promoTypes = "promo_types"
-    case reprint
-    case variation
-    case setId = "set_id"
-    case set
-    case setName = "set_name"
-    case setType = "set_type"
-    case setUri = "set_uri"
-    case setSearchUri = "set_search_uri"
-    case scryfallSetUri = "scryfall_set_uri"
-    case rulingsUri = "rulings_uri"
-    case printsSearchUri = "prints_search_uri"
-    case collectorNumber = "collector_number"
-    case digital
-    case rarity
-    case cardBackId = "card_back_id"
-    case artist
-    case artistIds = "artist_ids"
-    case illustrationId = "illustration_id"
-    case borderColor = "border_color"
-    case frame
-    case frameEffects = "frame_effects"
-    case securityStamp = "security_stamp"
-    case fullArt = "full_art"
-    case textless
-    case booster
-    case storySpotlight = "story_spotlight"
-    case edhrecRank = "edhrec_rank"
-    case prices
-    case relatedUris = "related_uris"
-    case purchaseUris = "purchase_uris"
-  }
 
   // swiftlint:disable function_body_length
   public init(
@@ -308,7 +242,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     frameEffects: [FrameEffect]? = nil,
     frame: Frame,
     fullArt: Bool,
-    securityStamp: String? = nil,
+    securityStamp: SecurityStamp? = nil,
     games: [Game],
     highresImage: Bool,
     illustrationId: UUID? = nil,
@@ -323,7 +257,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     purchaseUris: [String: String]? = nil,
     rarity: Card.Rarity,
     relatedUris: [String: String],
-    releasedAt: String,
+    releasedAt: String? = nil,
     reprint: Bool,
     scryfallSetUri: String,
     setName: String,

--- a/Sources/ScryfallKit/Models/Card/Card.swift
+++ b/Sources/ScryfallKit/Models/Card/Card.swift
@@ -208,6 +208,7 @@ public struct Card: Codable, Identifiable, Hashable, Sendable {
     case imageStatus = "image_status"
     case imageUris = "image_uris"
     case manaCost = "mana_cost"
+    case cardFaces = "card_faces"
     case cmc
     case typeLine = "type_line"
     case oracleText = "oracle_text"

--- a/Sources/ScryfallKit/Models/Enums.swift
+++ b/Sources/ScryfallKit/Models/Enums.swift
@@ -39,3 +39,7 @@ public enum Format: String, CaseIterable, Sendable {
 public enum Currency: String, CaseIterable, Sendable {
   case usd, eur, tix, usdFoil
 }
+
+public enum SecurityStamp: String, Codable, Sendable {
+  case oval, triangle, acorn, circle, arena, heart
+}

--- a/Sources/ScryfallKit/Networking/NetworkService.swift
+++ b/Sources/ScryfallKit/Networking/NetworkService.swift
@@ -19,7 +19,7 @@ protocol NetworkServiceProtocol: Sendable {
     as type: T.Type,
     completion: @Sendable @escaping (Result<T, Error>) -> Void
   )
-  @available(macOS 10.15.0, *, iOS 13.0.0, *)
+  @available(macOS 10.15.0, *, iOS 13.0.0, *, watchOS 11.0, *)
   func request<T: Decodable>(_ request: EndpointRequest, as type: T.Type) async throws -> T
 }
 
@@ -104,7 +104,7 @@ struct NetworkService: NetworkServiceProtocol, Sendable {
     }
   }
 
-  @available(macOS 10.15.0, *, iOS 13.0.0, *)
+  @available(macOS 10.15.0, *, iOS 13.0.0, *, watchOS 11.0, *)
   func request<T: Decodable>(_ request: EndpointRequest, as type: T.Type) async throws -> T
   where T: Sendable {
     try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ScryfallKit/ScryfallClient+Async.swift
+++ b/Sources/ScryfallKit/ScryfallClient+Async.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-@available(macOS 10.15.0, *, iOS 13.0.0, *)
+@available(macOS 10.15.0, *, iOS 13.0.0, *, watchOS 11.0, *)
 extension ScryfallClient {
   /// Equivalent to ``searchCards(filters:unique:order:sortDirection:includeExtras:includeMultilingual:includeVariations:page:completion:)`` but with async/await syntax
   public func searchCards(


### PR DESCRIPTION
I noticed while trying to decode a JSON response from Scryfall directly into a Card object that a lot of fields were either not accounted for or weren't listed as optional.

Also, in order to correctly decode the responses, accompanying CodingKeys needed to be defined for fields such as scryfallSetUri ->"scryfall_set_uri"

I know this is a much larger change, so please feel free to ask questions. I'm very open to feedback on this!

(Also the app I'm using to consume this framework has a watchos companion, so I needed to add availability for WatchOS as well. Honestly I see no reason to not just also include tvOS and VisionOS as well)