### PR TITLE
Manually URL re-encode everything so pluses and other regex characters survive.

### DIFF
--- a/Sources/ScryfallKit/Networking/EndpointRequests/EndpointRequest.swift
+++ b/Sources/ScryfallKit/Networking/EndpointRequests/EndpointRequest.swift
@@ -15,8 +15,10 @@ protocol EndpointRequest {
 extension EndpointRequest {
   var urlRequest: URLRequest? {
     var urlComponents = URLComponents(string: "https://api.scryfall.com/\(path)")
-    if !queryParams.isEmpty {
-      urlComponents?.queryItems = queryParams.compactMap { $0.value == nil ? nil : $0 }
+    urlComponents?.queryItems = queryParams.compactMap { $0.value == nil ? nil : $0 }
+    let queryItems = urlComponents?.queryItems
+    urlComponents?.percentEncodedQueryItems = queryItems?.map {
+      URLQueryItem(name: $0.name, value: $0.value?.addingPercentEncoding(withAllowedCharacters: .alphanumerics))
     }
 
     guard let url = urlComponents?.url else {


### PR DESCRIPTION
Queries including regex terms with `+` will inadvertently mangle the URL and cause the request to fail, because `+` is considered a URL-safe character representing space. When they are preserved and interpreted by Scryfall as a space, which is the correct thing for Scryfall to do, they cause the query to appear unterminated in the middle of a regex expression, and then for the URL to have a bunch of garbage at the end.

This PR is a bit of a sledgehammer, but it URL-encodes everything from the query that isn't alphanumeric while avoiding double-encoding issues from other attempted solutions. This is both because I was intending to be extremely conservative, and because I wasn't able to find a built-in character set that was more selective (and didn't want to get into the business of defining a custom character set).

I'm unsure how to test this other than to say I have been using it in my project successfully.

I'm also a little surprised that this happens at all; I would have thought that `queryItems` would automatically do the Right Thing with arbitrary strings you give it as arguments but it seems more inclined to just slap them into the URL more or less as-is.