### PR TITLE
Add missing fields; add missing standard conformances; improve HTTP error reporting and configuration

### DIFF
--- a/Sources/ScryfallKit/Extensions/Card+helpers.swift
+++ b/Sources/ScryfallKit/Extensions/Card+helpers.swift
@@ -65,10 +65,12 @@ extension Card {
   public func getPrice(for currency: Currency) -> String? {
     switch currency {
     case .usd: return prices.usd
-    case .eur: return prices.eur
-    case .tix: return prices.tix
     case .usdFoil: return prices.usdFoil
     case .usdEtched: return prices.usdEtched
+    case .eur: return prices.eur
+    case .eurFoil: return prices.eurFoil
+    case .eurEtched: return prices.eurEtched
+    case .tix: return prices.tix
     }
   }
 }

--- a/Sources/ScryfallKit/Models/Card/Card+Face.swift
+++ b/Sources/ScryfallKit/Models/Card/Card+Face.swift
@@ -25,6 +25,8 @@ extension Card {
     public var colors: [Card.Color]?
     /// This face's defense, if any
     public var defense: String?
+    /// The just-for-fun name printed on the card (such as for Godzilla series cards).
+    public var flavorName: String?
     /// This card's flavor text if any
     public var flavorText: String?
     /// An ID for this card face's art that remains consistent across reprints
@@ -64,6 +66,7 @@ extension Card {
       colorIndicator: [Card.Color]? = nil,
       colors: [Card.Color]? = nil,
       defense: String? = nil,
+      flavorName: String? = nil,
       flavorText: String? = nil,
       illustrationId: UUID? = nil,
       imageUris: ImageUris? = nil,
@@ -83,6 +86,7 @@ extension Card {
       self.colorIndicator = colorIndicator
       self.colors = colors
       self.defense = defense
+      self.flavorName = flavorName
       self.flavorText = flavorText
       self.illustrationId = illustrationId
       self.imageUris = imageUris

--- a/Sources/ScryfallKit/Models/Card/Card+Prices.swift
+++ b/Sources/ScryfallKit/Models/Card/Card+Prices.swift
@@ -13,16 +13,22 @@ extension Card {
     public var usdFoil: String?
     /// The price of this card's etched printing in usd
     public var usdEtched: String?
-    /// The price of this card in eur.
+    /// The price of this card in eur
     public var eur: String?
+    /// The price of this card's foil printing in eur
+    public var eurFoil: String?
+    /// The price of this card's etched printing in eur
+    public var eurEtched: String?
 
-    public init(tix: String? = nil, usd: String? = nil, usdFoil: String? = nil, usdEtched: String? = nil, eur: String? = nil)
+    public init(tix: String? = nil, usd: String? = nil, usdFoil: String? = nil, usdEtched: String? = nil, eur: String? = nil, eurFoil: String? = nil, eurEtched: String? = nil)
     {
       self.tix = tix
       self.usd = usd
       self.usdFoil = usdFoil
       self.usdEtched = usdEtched
       self.eur = eur
+      self.eurFoil = eurFoil
+      self.eurEtched = eurEtched
     }
   }
 }

--- a/Sources/ScryfallKit/Models/Card/Card+RelatedCard.swift
+++ b/Sources/ScryfallKit/Models/Card/Card+RelatedCard.swift
@@ -8,7 +8,7 @@ extension Card {
   /// A Magic card that's related to another Magic card
   ///
   /// - Note: In the documentation of this struct, "this card" will refer to the `RelatedCard` object while "the original card" will refer to the `Card` object that contains this object
-  public struct RelatedCard: Codable, Hashable, Sendable {
+  public struct RelatedCard: Codable, Identifiable, Hashable, Sendable {
     /// The type of relationship
     public enum Component: String, Codable, CaseIterable, Hashable, Sendable {
       /// This card is a token that's made by the original card

--- a/Sources/ScryfallKit/Models/Enums.swift
+++ b/Sources/ScryfallKit/Models/Enums.swift
@@ -39,5 +39,5 @@ public enum Format: String, CaseIterable, Sendable {
 
 /// Currency types that Scryfall provides prices for
 public enum Currency: String, CaseIterable, Sendable {
-  case usd, eur, tix, usdFoil, usdEtched
+  case usd, usdFoil, usdEtched, eur, eurFoil, eurEtched, tix
 }

--- a/Sources/ScryfallKit/Models/Enums.swift
+++ b/Sources/ScryfallKit/Models/Enums.swift
@@ -31,13 +31,13 @@ public enum SortDirection: String, Codable, CaseIterable, Sendable {
 }
 
 /// Formats for playing Magic: the Gathering
-public enum Format: String, CaseIterable, Sendable {
+public enum Format: String, Codable, CaseIterable, Sendable {
   case standard, future, historic, timeless, gladiator, pioneer, modern, legacy, pauper, vintage,
     penny, commander, oathbreaker, standardbrawl, brawl, alchemy, paupercommander, duel, oldschool,
     premodern, predh
 }
 
 /// Currency types that Scryfall provides prices for
-public enum Currency: String, CaseIterable, Sendable {
+public enum Currency: String, Codable, CaseIterable, Sendable {
   case usd, usdFoil, usdEtched, eur, eurFoil, eurEtched, tix
 }

--- a/Sources/ScryfallKit/Networking/NetworkService.swift
+++ b/Sources/ScryfallKit/Networking/NetworkService.swift
@@ -52,23 +52,32 @@ struct NetworkService: NetworkServiceProtocol, Sendable {
       throw error
     }
 
-    guard let content = data else {
-      throw ScryfallKitError.noDataReturned
-    }
-
     guard let httpStatus = (response as? HTTPURLResponse)?.statusCode else {
       throw ScryfallKitError.failedToCast("httpStatus property of response to HTTPURLResponse")
+    }
+
+    logger?.debug("HTTP \(httpStatus): \(data.flatMap { String(data: $0, encoding: .utf8) } ?? "Couldn't represent response body as string")")
+
+    guard let content = data else {
+      throw ScryfallKitError.noDataReturned
     }
 
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
 
     if (200..<300).contains(httpStatus) {
-      let responseBody = String(data: content, encoding: .utf8)
-      logger?.debug("\(responseBody ?? "Couldn't represent response body as string")")
-      return try decoder.decode(dataType, from: content)
+      do {
+        return try decoder.decode(dataType, from: content)
+      } catch {
+        throw ScryfallKitError.failedToDecode(content)
+      }
     } else {
-      let httpError = try decoder.decode(ScryfallError.self, from: content)
+      let httpError: ScryfallError
+      do {
+        httpError = try decoder.decode(ScryfallError.self, from: content)
+      } catch {
+        throw ScryfallKitError.httpError(httpStatus, content)
+      }
       throw ScryfallKitError.scryfallError(httpError)
     }
   }

--- a/Sources/ScryfallKit/Networking/NetworkService.swift
+++ b/Sources/ScryfallKit/Networking/NetworkService.swift
@@ -15,9 +15,11 @@ protocol NetworkServiceProtocol: Sendable {
 }
 
 struct NetworkService: NetworkServiceProtocol, Sendable {
+  let userAgent: String?
   let logger: Logger?
 
-  init(logger: Logger?) {
+  init(userAgent: String?, logger: Logger?) {
+    self.userAgent = userAgent
     self.logger = logger
   }
 
@@ -25,10 +27,14 @@ struct NetworkService: NetworkServiceProtocol, Sendable {
     _ request: EndpointRequest, as type: T.Type,
     completion: @Sendable @escaping (Result<T, Error>) -> Void
   ) {
-    guard let urlRequest = request.urlRequest else {
+    guard var urlRequest = request.urlRequest else {
       logger?.error("Invalid url request")
       completion(.failure(ScryfallKitError.invalidUrl))
       return
+    }
+
+    if let userAgent {
+      urlRequest.setValue(userAgent, forHTTPHeaderField: "User-Agent")
     }
 
     logger?.trace("Starting request: \(urlRequest.debugDescription)")

--- a/Sources/ScryfallKit/ScryfallClient.swift
+++ b/Sources/ScryfallKit/ScryfallClient.swift
@@ -10,9 +10,11 @@ public final class ScryfallClient: Sendable {
   let networkService: NetworkServiceProtocol
 
   /// Initialize an instance of the ScryfallClient
-  /// - Parameter logger: The logger to use. Pass nil to disable logging
-  public init(logger: Logger? = nil) {
-    self.networkService = NetworkService(logger: logger)
+  /// - Parameters:
+  ///   - userAgent: The value for the HTTP User-Agent header; required by Scryfall's API usage terms
+  ///   - logger: The logger to use. Pass nil to disable logging
+  public init(userAgent: String? = nil, logger: Logger? = nil) {
+    self.networkService = NetworkService(userAgent: userAgent, logger: logger)
   }
 
   /// Perform a search using an array of ``CardFieldFilter`` objects.

--- a/Sources/ScryfallKit/ScryfallKitError.swift
+++ b/Sources/ScryfallKit/ScryfallKitError.swift
@@ -13,6 +13,8 @@ public enum ScryfallKitError: LocalizedError, CustomStringConvertible {
   case singleFacedCard
   case noDataReturned
   case failedToCast(String)
+  case failedToDecode(Data)
+  case httpError(Int, Data)
 
   public var errorDescription: String? {
     description
@@ -30,6 +32,10 @@ public enum ScryfallKitError: LocalizedError, CustomStringConvertible {
       return "No data was returned by the server"
     case .failedToCast(let details):
       return "Failed to cast \(details)"
+    case .failedToDecode:
+      return "Failed to decode response into valid JSON"
+    case .httpError(let statusCode, _):
+      return "Failed with HTTP \(statusCode)"
     }
   }
 }


### PR DESCRIPTION
This PR is a grab bag of small changes I made over the course of developing my own project. It includes:

- adding missing fields: EUR foil/etched prices and `Card.flavorName`
- adding missing conformances: `Identifiable` and `Codable` on a couple structs that should probably have it like many others do
- configurable `User-Agent` header: [Scryfall's API docs](https://scryfall.com/docs/api) require that you identify yourself with a unique name and don't use library defaults
- refined HTTP error handling (breaking change due to new enum members)
  - response-decoding failures are reported explicitly rather than allowing them to throw whatever random decoding error so that we can report the original undecoded bytes back to the caller
  - error responses that do not parse from JSON as a well-formed ScryfallError are reported as generic HTTP errors -- this can happen when Scryfall's reverse proxy dumps a default 503 HTML page on you

Sorry it's a bit jumbled. I can split it if up if you'd prefer.

To be honest, the error handling improvements have in practice been pretty marginal, especially the decoding one. The HTTP error one was added after a spurt of 503/504s I got from Scryfall, which allowed me to tell users that Scryfall was down rather than the dreaded "unknown error" (combined with the error object's misleading explanation about failing to decode the response, which was not the root cause).